### PR TITLE
Add Swift support and clean up code

### DIFF
--- a/OldABI.h
+++ b/OldABI.h
@@ -4,5 +4,6 @@
 
 #include <stdio.h>
 #include "patchfind.h"
+#include "subtype.h"
 
 #endif /* OldABI_h */

--- a/OldABI.swift
+++ b/OldABI.swift
@@ -1,185 +1,61 @@
-
 import Foundation
 import MachO
 
-typealias FileHandleC = UnsafeMutablePointer<FILE>
-extension FileHandleC {
-    @inline(__always)
-    func readData(ofLength count: Int) -> UnsafeMutableRawPointer {
-        let alloc = malloc(count)
-        fread(alloc, 1, count, self)
-        return alloc!
-    }
-    
-    @discardableResult @inline(__always)
-    func seek(toFileOffset offset: UInt64) -> UnsafeMutablePointer<FILE> {
-        var pos: fpos_t = .init(offset)
-        fsetpos(self, &pos)
-        return self
-    }
-    
-    @inline(__always)
-    var offsetInFile: UInt64 {
-        var pos: fpos_t = 0
-        fgetpos(self, &pos)
-        return .init(pos)
-    }
-    
-    @inline(__always)
-    func close() {
-        fclose(self)
-    }
-}
+private let ekhandle = dlopen("/var/jb/usr/lib/libellekit.dylib", RTLD_NOW);
 
-let ekhandle = dlopen("/var/jb/usr/lib/libellekit.dylib", RTLD_NOW);
-
-let hookMemory = {
-    unsafeBitCast(dlsym(ekhandle, "MSHookMemory"), to: (@convention (c) (UnsafeRawPointer, UnsafeRawPointer, size_t) -> Void).self)
+private let hookMemory = {
+    unsafeBitCast(dlsym(ekhandle, "MSHookMemory"), to: (@convention(c) (UnsafeRawPointer, UnsafeRawPointer, size_t) -> Void).self)
 }()
 
-let hookFunction = {
-    unsafeBitCast(dlsym(ekhandle, "MSHookFunction"), to: (@convention (c) (UnsafeRawPointer, UnsafeRawPointer, UnsafeMutablePointer<UnsafeMutableRawPointer?>?) -> Void).self)
-}()
-
-func oneshot_fix_oldabi() {
-    for image in 0..<_dyld_image_count() {
-        if String(cString: _dyld_get_image_name(image)) == "/usr/lib/libobjc.A.dylib" ||
-            String(cString: _dyld_get_image_name(image)) == "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation" {
-            var bytes: [UInt8] = [
-                0x00, 0x18, 0xC1, 0xDA
-            ]
-            
-            var mask: [UInt8] = [
-                0x00, 0xFC, 0xFF, 0xFF
-            ]
-            
-            while true {
-                let autda = patchfind_find(Int32(image), &bytes, &mask, 4)
-                                
-                if let autda {
-                    hookMemory(autda, [
-                        CFSwapInt32(0xF047C1DA) // xpacd x16
-                    ], 4)
-                } else {
-                    break
-                }
-            }
-        }
-    }
-}
-
-func looksLegacy(_ path: UnsafePointer<CChar>) -> Bool {
-    guard let handle = fopen(path, "r") else {
-        return false
-    }
+private func oneshot_fix_oldabi() {
+    let count = _dyld_image_count()
     
-    defer { handle.close() }
+    var bytes: [UInt8] = [
+        0x00, 0x18, 0xC1, 0xDA
+    ]
     
-    let machHeaderPointer = handle
-        .readData(ofLength: MemoryLayout<mach_header_64>.size)
+    var mask: [UInt8] = [
+        0x00, 0xFC, 0xFF, 0xFF
+    ]
     
-    defer { machHeaderPointer.deallocate() }
-    
-    if machHeaderPointer.assumingMemoryBound(to: mach_header_64.self).pointee.magic == FAT_CIGAM {
-        // we have a fat binary
-        // get our current cpu subtype
-        let nslices = handle
-            .seek(toFileOffset: 0x4)
-            .readData(ofLength: MemoryLayout<UInt32>.size)
-            .assumingMemoryBound(to: UInt32.self)
-            .pointee.bigEndian
-                        
-        for i in 0..<nslices {
-            let slice_ptr = handle
-                .seek(toFileOffset: UInt64(8 + (Int(i) * 20)))
-                .readData(ofLength: MemoryLayout<fat_arch>.size)
-                .assumingMemoryBound(to: fat_arch.self)
-            
-            let slice = slice_ptr.pointee
-            
-            defer { slice_ptr.deallocate() }
-            
-            if slice.cputype.bigEndian == CPU_TYPE_ARM64 {
-                                            
-                let slice_ptr = handle
-                    .seek(toFileOffset: UInt64(8 + (Int(i) * 20)))
-                    .readData(ofLength: MemoryLayout<fat_arch>.size)
-                    .assumingMemoryBound(to: fat_arch.self)
-                
-                let slice = slice_ptr.pointee
-                
-                defer { slice_ptr.deallocate() }
-                                
-                if slice.cpusubtype == 0x2000080 { // new abi
-                    return false
-                }
-                
-                if slice.cpusubtype == 0x2000000 { // old abi
-                    return true
-                }
-            }
-        }
-    }
-    
-    return false
-}
-
-typealias dlopen_body = @convention(c) (UnsafePointer<CChar>, Int32) -> UnsafeRawPointer
-
-let orig: UnsafeMutablePointer<UnsafeMutableRawPointer?> = .allocate(capacity: 8)
-
-@_cdecl("dlopen_hook_oldabi")
-func dlopen_hook_oldabi(_ path: UnsafePointer<CChar>, _ loadtype: Int32) -> UnsafeRawPointer {
-    if looksLegacy(path) {
-        oneshot_fix_oldabi()
-    }
+    for image in 0..<count {
+        let name = String(cString: _dyld_get_image_name(image))
         
-    return unsafeBitCast(orig.pointee, to: dlopen_body.self)(path, loadtype)
-}
-
-struct Info: Codable {
-    var CFBundleExecutable: String?
-}
-
-func fixupPreferences() throws {
-    let bundlePath = ("/var/jb/Library/PreferenceBundles/" as NSString).resolvingSymlinksInPath
-    let files = try FileManager.default.contentsOfDirectory(atPath: bundlePath)
-    for file in files {
-        if file.hasSuffix(".bundle") {
-            let info = bundlePath+"/"+file+"/Info.plist"
-            if FileManager.default.fileExists(atPath: info),
-               let infoData = try? Data(contentsOf: NSURL.fileURL(withPath: info)),
-               let infoRoot = try? PropertyListDecoder().decode(Info.self, from: infoData),
-               let exec = infoRoot.CFBundleExecutable,
-               looksLegacy(bundlePath+"/"+file+"/"+exec) {
-                oneshot_fix_oldabi()
+        if name == "/usr/lib/libobjc.A.dylib" || name == "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation" || name == "/usr/lib/swift/libswiftCore.dylib" {
+            while true {
+                guard let autda = patchfind_find(image, &bytes, &mask, 4) else { break }
+                
+                hookMemory(autda, [
+                    CFSwapInt32(0xF047C1DA) // xpacd x16
+                ], 4)
             }
         }
     }
 }
 
 @_cdecl("swift_ctor")
-public func ctor() {
-	let whitelist = [
-		"/System/Library/CoreServices/SpringBoard.app/SpringBoard",
-		"/Applications/",
-		"/usr/sbin/mediaserverd",
-		"/usr/libexec/backboardd",
-		"/usr/libexec/nfcd"
-	].map {
-		ProcessInfo.processInfo.arguments[0].hasPrefix($0)
-	}.contains(true)
+func ctor() {
+    guard let executablePath = ProcessInfo.processInfo.arguments.first else { return }
+    
+    let whitelist = [
+        "/System/Library/CoreServices/SpringBoard.app/SpringBoard",
+        "/Applications/",
+        "/usr/sbin/mediaserverd",
+        "/usr/libexec/backboardd",
+        "/usr/libexec/nfcd"
+    ].map {
+        executablePath.hasPrefix($0)
+    }.contains(true)
 
-    if !whitelist && !(ProcessInfo.processInfo.arguments.first?.contains("/procursus/Applications/") == true) {
+    if !whitelist && !executablePath.contains("/procursus/Applications/") {
         return
     }
-
-    if ProcessInfo.processInfo.arguments.first?.contains("/Applications/Preferences.app/Preferences") == true {
-        try? fixupPreferences()
-    }
-
-    let repcl: @convention(c) (UnsafePointer<CChar>, Int32) -> UnsafeRawPointer = dlopen_hook_oldabi
-    let repptr = unsafeBitCast(repcl, to: UnsafeMutableRawPointer.self)
     
-    hookFunction(dlsym(dlopen(nil, RTLD_NOW), "dlopen"), repptr, orig)
+    _dyld_register_func_for_add_image { header, _ in
+        guard let header else { return }
+        
+        if looksLegacy(header) {
+            oneshot_fix_oldabi()
+        }
+    }
 }

--- a/OldABI.xcodeproj/project.pbxproj
+++ b/OldABI.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		9EF3204C29D4CD8C00175976 /* OldABI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EF3204A29D4CD8C00175976 /* OldABI.swift */; };
 		9EF3204F29D4CE0700175976 /* patchfind.h in Headers */ = {isa = PBXBuildFile; fileRef = 9EF3204D29D4CE0700175976 /* patchfind.h */; };
 		9EF3205029D4CE0700175976 /* patchfind.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EF3204E29D4CE0700175976 /* patchfind.m */; };
+		E4D8FC9E2DB9D9CB003FAC62 /* subtype.c in Sources */ = {isa = PBXBuildFile; fileRef = E4D8FC9D2DB9D9C8003FAC62 /* subtype.c */; };
+		E4D8FCA02DB9D9D2003FAC62 /* subtype.h in Headers */ = {isa = PBXBuildFile; fileRef = E4D8FC9F2DB9D9D1003FAC62 /* subtype.h */; };
+		E4D8FCA22DB9DB6C003FAC62 /* load.s in Sources */ = {isa = PBXBuildFile; fileRef = E4D8FCA12DB9DB67003FAC62 /* load.s */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -34,6 +37,9 @@
 		9EF3204A29D4CD8C00175976 /* OldABI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldABI.swift; sourceTree = "<group>"; };
 		9EF3204D29D4CE0700175976 /* patchfind.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = patchfind.h; sourceTree = "<group>"; };
 		9EF3204E29D4CE0700175976 /* patchfind.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = patchfind.m; sourceTree = "<group>"; };
+		E4D8FC9D2DB9D9C8003FAC62 /* subtype.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = subtype.c; sourceTree = "<group>"; };
+		E4D8FC9F2DB9D9D1003FAC62 /* subtype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = subtype.h; sourceTree = "<group>"; };
+		E4D8FCA12DB9DB67003FAC62 /* load.s */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.asm; path = load.s; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +71,9 @@
 		9EF3203929D4CD8200175976 = {
 			isa = PBXGroup;
 			children = (
+				E4D8FCA12DB9DB67003FAC62 /* load.s */,
+				E4D8FC9F2DB9D9D1003FAC62 /* subtype.h */,
+				E4D8FC9D2DB9D9C8003FAC62 /* subtype.c */,
 				9EF3204929D4CD8C00175976 /* OldABI.h */,
 				9EF3204A29D4CD8C00175976 /* OldABI.swift */,
 				9EF3204D29D4CE0700175976 /* patchfind.h */,
@@ -91,6 +100,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9EF3204F29D4CE0700175976 /* patchfind.h in Headers */,
+				E4D8FCA02DB9D9D2003FAC62 /* subtype.h in Headers */,
 				9EF3204B29D4CD8C00175976 /* OldABI.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -183,7 +193,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				9EF3204C29D4CD8C00175976 /* OldABI.swift in Sources */,
+				E4D8FC9E2DB9D9CB003FAC62 /* subtype.c in Sources */,
 				9EF3205029D4CE0700175976 /* patchfind.m in Sources */,
+				E4D8FCA22DB9DB6C003FAC62 /* load.s in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/load.s
+++ b/load.s
@@ -1,0 +1,3 @@
+.mod_init_func
+.align 4
+.quad _swift_ctor

--- a/patchfind.h
+++ b/patchfind.h
@@ -1,2 +1,2 @@
 void *patchfind_seek_back(void *startPtr, uint32_t toInstruction, uint32_t mask, unsigned int maxSearch);
-void *patchfind_find(int imageIndex, unsigned char *bytesToSearch, unsigned char *byteMask, size_t byteCount);
+void *patchfind_find(unsigned int imageIndex, unsigned char *bytesToSearch, unsigned char *byteMask, size_t byteCount);

--- a/subtype.c
+++ b/subtype.c
@@ -1,0 +1,28 @@
+#import "subtype.h"
+
+bool looksLegacy(const struct mach_header *_Nonnull mh) {
+    if (mh->magic == FAT_CIGAM || mh->magic == FAT_MAGIC) {
+        const struct fat_header *fh = (const struct fat_header *)mh;
+        struct fat_arch *arch = (struct fat_arch *)(mh + sizeof(struct fat_header));
+
+        for (uint32_t i = 0; i < OSSwapBigToHostInt32(fh->nfat_arch); ++i) {
+            const struct mach_header_64 *sh = (const struct mach_header_64 *)(mh + OSSwapBigToHostInt32(arch->offset));
+
+            if ((sh->cpusubtype & ~CPU_SUBTYPE_MASK) == CPU_SUBTYPE_ARM64E) {
+                if (!(sh->cpusubtype & CPU_SUBTYPE_PTRAUTH_ABI)) {
+                    return true;
+                }
+            }
+
+            arch += 1;
+        }
+    } else if (mh->magic == MH_MAGIC_64 || mh->magic == MH_CIGAM_64) {
+        if ((mh->cpusubtype & ~CPU_SUBTYPE_MASK) == CPU_SUBTYPE_ARM64E) {
+            if (!(mh->cpusubtype & CPU_SUBTYPE_PTRAUTH_ABI)) {
+                return true;
+            }
+        }
+    }
+    
+    return false;
+}

--- a/subtype.h
+++ b/subtype.h
@@ -1,0 +1,5 @@
+#import <mach-o/dyld.h>
+#import <mach-o/loader.h>
+#import <mach-o/fat.h>
+
+bool looksLegacy(const struct mach_header *_Nonnull mh);


### PR DESCRIPTION
The aim of this PR is to add support for Swift binaries compiled with the old arm64e ABI and to clean up the codebase.
Changelog:
- Simplify whitelist logic
- Add `libswiftCore` support
- Use `_dyld_register_func_for_add_image` instead of a dlopen hook
- Use more standardized logic to detect the old arm64e ABI in a Mach-O (from my project https://github.com/NightwindDev/oldabichecker)
- Move `swift_ctor` logic to `load.s`